### PR TITLE
Fix click on tags component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [keepachangelog.com](http://keepachangelog.com/).
 
 ## [unreleased]
+### Fixed
+- Fix click on tags component doesn't open edit input
 
 ## [0.5.1] - 2016-03-06
 ### Fixed

--- a/lib/react/cells/tags-component.js
+++ b/lib/react/cells/tags-component.js
@@ -20,7 +20,7 @@ export default React.createClass({
   render () {
     if (this.state.isEditing) {
       return (
-        <td className='tv-td--tags'>
+        <td className='tv-td--tags' onClick={this._stopPropagation}>
           <EditComponent initialVal={this.props.tags} save={this._save} abort={this._abort} />
         </td>
       )
@@ -43,8 +43,13 @@ export default React.createClass({
     this._unsub()
   },
 
-  _editIfSelected () {
+  _stopPropagation (ev) {
+    ev && ev.stopPropagation()
+  },
+
+  _editIfSelected (ev) {
     if (this.props.isSelected) {
+      this._stopPropagation(ev)
       this.setState({ isEditing: true })
     }
   },

--- a/spec/react/cells/tags-component-spec.js
+++ b/spec/react/cells/tags-component-spec.js
@@ -4,11 +4,12 @@ import { React, TestUtils } from 'react-for-atom'
 import TagsComponent from '../../../lib/react/cells/tags-component'
 
 describe('react/cells/tags-component', function () {
-  let renderer, r, tags
+  let renderer, r, tags, clickEvent
 
   beforeEach(function () {
     renderer = TestUtils.createRenderer()
     tags = 'a b c'
+    clickEvent = jasmine.createSpyObj('clickEvent', ['stopPropagation'])
   })
 
   it('renders tags as indidvidual items', function () {
@@ -23,18 +24,30 @@ describe('react/cells/tags-component', function () {
   it('does nothing on click since not selected', function () {
     r.props.onClick()
     expect(r.props.children.length).toBe(3)
+    expect(clickEvent.stopPropagation).not.toHaveBeenCalled();
   })
 
   describe('when clicked and is selected', function () {
     beforeEach(function () {
       renderer.render(<TagsComponent tags={tags} isSelected />)
       r = renderer.getRenderOutput()
-      r.props.onClick()
+      r.props.onClick(clickEvent)
       r = renderer.getRenderOutput() // to get updated output
     })
 
     it('should render an edit component instead', function () {
       expect(r.props.children.type.displayName).toEqual('edit-component')
     })
+
+    it('stops propagation of event', function () {
+      expect(clickEvent.stopPropagation).toHaveBeenCalled();
+      expect(clickEvent.stopPropagation.calls.length).toEqual(1);
+    });
+
+    it('stops propagation and focus on input on sequent clicks', function () {
+      r = renderer.getRenderOutput()
+      r.props.onClick(clickEvent)
+      expect(clickEvent.stopPropagation.calls.length).toEqual(2);
+    });
   })
 })


### PR DESCRIPTION
Edit on click, by stopping click event to propagate (and thus re-selecting item).