### PR TITLE
Fix note stats not being updated on file change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [keepachan
 ### Added
 - #22 Allow to change default/new file extension
 
+### Fixed
+- Note stats was not updated on changes like before (ee00e9f)
+
 ## [0.8.0] - 2016-10-04
 [Happy Cinnamon Bun Day! :tada:](http://kanelbullensdag.se/en/)
 

--- a/decls/textual-velocity/file-reader-type.js
+++ b/decls/textual-velocity/file-reader-type.js
@@ -1,4 +1,4 @@
 declare type FileReaderType = {
   notePropName: string,
-  read (path: string, callback: NodeCallbackType): void
+  read (path: string, fileStats: FsStatsType, callback: NodeCallbackType): void
 }

--- a/lib/file-readers/stats-file-reader.js
+++ b/lib/file-readers/stats-file-reader.js
@@ -1,12 +1,10 @@
 /* @flow */
 
-import fs from 'fs'
-
 export default {
 
-  notePropName: 'content',
+  notePropName: 'stats',
 
   read (path: string, stats: FsStatsType, callback: NodeCallbackType) {
-    fs.readFile(path, 'utf8', callback)
+    callback(null, stats)
   }
 }

--- a/lib/path-watcher-factory.js
+++ b/lib/path-watcher-factory.js
@@ -55,12 +55,12 @@ export default class PathWatcherFactory {
         .sampledBy(filesStream) // only trigger stream on file changes
         .bufferingThrottle(0) // ms, throttle files enough to avoid making app unresponsive
         .flatMap((t: {file: FileType, fileReaders: Array<FileReaderType>}) => {
-          const {filename} = t.file
+          const {filename, stats: fileStats} = t.file
 
           let fileReaders = t.fileReaders
           if (notes) {
             const note = notes[filename]
-            if (note && note.stats.mtime.getTime() === t.file.stats.mtime.getTime()) {
+            if (note && note.stats.mtime.getTime() === fileStats.mtime.getTime()) {
               fileReaders = fileReaders.filter(fileReader => note[fileReader.notePropName] === undefined)
             }
             if (fileReaders.length === 0) return Bacon.never() // e.g. a cached note that have all read values already
@@ -75,7 +75,7 @@ export default class PathWatcherFactory {
                 value: null
               }
               return Bacon
-                .fromNodeCallback(fileReader.read, notesPath.fullPath(filename))
+                .fromNodeCallback(fileReader.read, notesPath.fullPath(filename), fileStats)
                 .map(value => {
                   readResult.value = value === undefined ? null : value // make sure value cannot be undefined
                   return readResult

--- a/lib/service-consumers/defaults.js
+++ b/lib/service-consumers/defaults.js
@@ -4,6 +4,7 @@ import Disposables from '../disposables'
 import FileIconColumn from '../columns/file-icon-column'
 import StatsDateColumn from '../columns/stats-date-column'
 import SummaryColumn from '../columns/summary-column'
+import statsFileReader from '../file-readers/stats-file-reader'
 import contentFileReader from '../file-readers/content-file-reader'
 import StatsDateField from '../fields/stats-date-field'
 import ParsedPathField from '../fields/parsed-path-field'
@@ -16,7 +17,7 @@ const BIRTHTIME_FIELD = 'birthtime'
 export default {
 
   consumeServiceV0 (service: ServiceV0Type, summaryEditCellName: string) {
-    service.registerFileReaders(contentFileReader)
+    service.registerFileReaders(statsFileReader, contentFileReader)
 
     service.registerFields(
       contentFileReader,

--- a/lib/service-consumers/nv-tags.js
+++ b/lib/service-consumers/nv-tags.js
@@ -52,7 +52,7 @@ module.exports = {
     service.registerFileReaders({
       notePropName: FILE_PROP_NAME,
 
-      read: function (path, callback) {
+      read: function (path, stats, callback) {
         if (!xattr) return callback(new Error('xattr no longer available, probably due to package being deactivated while in transit'))
 
         xattr.get(path, XATTR_KEY, function (err, plistBuf) {

--- a/spec/path-watcher-factory-spec.js
+++ b/spec/path-watcher-factory-spec.js
@@ -17,7 +17,7 @@ describe('path-watcher-factory', () => {
     jasmine.useRealClock()
 
     testFileReader = {
-      read: (path, callback) => callback(null, path),
+      read: (path, stats, callback) => callback(null, path),
       notePropName: 'test'
     }
     spyOn(testFileReader, 'read').andCallThrough()

--- a/spec/service-consumers/nv-tags-spec.js
+++ b/spec/service-consumers/nv-tags-spec.js
@@ -90,6 +90,7 @@ describe('service-consumers/nv-tags', function () {
 
   describe('registered file reader+writer', function () {
     var fileReader, fileWriter, path, callback
+    var fileStats = {}
 
     beforeEach(function () {
       fileReader = v0.registerFileReaders.mostRecentCall.args[0]
@@ -111,7 +112,7 @@ describe('service-consumers/nv-tags', function () {
       runs(function () {
         expect(writeSpy.mostRecentCall.args[0]).toBeFalsy()
         expect(writeSpy.mostRecentCall.args[1]).toBeFalsy()
-        fileReader.read(tmpFile.path, readSpy)
+        fileReader.read(tmpFile.path, fileStats, readSpy)
       })
 
       waitsFor(function () {
@@ -125,7 +126,7 @@ describe('service-consumers/nv-tags', function () {
 
     it('should return null for a read file that have no xattrs set', function () {
       path = Path.join(__dirname, '..', 'fixtures', 'standard', 'empty.md')
-      fileReader.read(path, callback)
+      fileReader.read(path, fileStats, callback)
       waitsFor(function () {
         return callback.calls.length >= 1
       })
@@ -136,7 +137,7 @@ describe('service-consumers/nv-tags', function () {
     })
 
     it('should return error if read file does not exist', function () {
-      fileReader.read('nonexisting', callback)
+      fileReader.read('nonexisting', fileStats, callback)
       waitsFor(function () {
         return callback.calls.length >= 1
       })


### PR DESCRIPTION
The file-reader was removed at some earlier point, since the stats was read with the initial file read, but missed to propagate the new stats object from the (temporary) file to the persistent note for the last-updated field to be updated.