### PR TITLE
Fix regression, not opening text editor for new note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [keepachangelog.com](http://keepachangelog.com/).
 
 ## [unreleased]
+#### Fixed
+- Regression from previous fix, preventing new note from being created on <kbd>enter</kbd>
 
 ## [0.11.1] - 2016-12-04
 #### Fixed

--- a/decls/textual-velocity/presenter-type.js
+++ b/decls/textual-velocity/presenter-type.js
@@ -5,6 +5,7 @@ declare type PresenterType = {
   listHeightP: Bacon.Property,
   loadingProgressP: Bacon.Property,
   loadingS: Bacon.Stream,
+  newPathP: Bacon.Property,
   openPathS: Bacon.Stream,
   paginationP: Bacon.Property,
   rowHeightP: Bacon.Property,

--- a/lib/presenter.js
+++ b/lib/presenter.js
@@ -13,6 +13,7 @@ export default class Presenter {
   listHeightP: Bacon.Property
   loadingProgressP: Bacon.Property
   loadingS: Bacon.Stream
+  newPathP: Bacon.Property
   openPathS: Bacon.Stream
   paginationP: Bacon.Property
   rowHeightP: Bacon.Property
@@ -129,16 +130,13 @@ export default class Presenter {
           int.editCellNameP.changes(),
           int.sifterResultP.toEventStream()))
 
-    this.openPathS = Bacon
+    this.openPathS = int.openFileS
+    this.newPathP = Bacon
       .combineTemplate({
-        selectedPath: this.selectedPathP,
         searchStr: this.searchStrP,
         notesPath: int.notesPathP
       })
-      .sampledBy(int.openFileS)
-      .map(({selectedPath, searchStr, notesPath}) => {
-        if (selectedPath) return selectedPath
-
+      .map(({searchStr, notesPath}) => {
         searchStr = searchStr.trim() || 'untitled'
         const filename = HAS_FILE_EXT_REGEX.test(searchStr)
           ? searchStr

--- a/lib/side-effects.js
+++ b/lib/side-effects.js
@@ -32,7 +32,7 @@ export default class SideEffects {
       this._renderLoadingOnLoadingEvent(presenter, view),
       this._renderResultsOnDataChanges(presenter, view),
       this._previewSelectedPath(presenter),
-      this._openTextEditorOnOpenEvent(presenter.openPathS, presenter.selectedPathP),
+      this._openTextEditorOnOpenEvent(presenter),
       this._saveEditedCellOnSave(presenter.saveEditedCellContentS, service.fileWritersP),
       this._updateConfigSchemaOnColumnsChange(service.columnsP),
       this._informAboutRestartingSessionForChangesToTakeEffect()
@@ -211,13 +211,18 @@ export default class SideEffects {
         }))
   }
 
-  _openTextEditorOnOpenEvent (openPathS: Bacon.Stream, selectedPathP: Bacon.Property) {
-    return selectedPathP
+  _openTextEditorOnOpenEvent (presenter: PresenterType) {
+    return Bacon
+      .combineTemplate({
+        selectedPath: presenter.selectedPathP,
+        newPath: presenter.newPathP
+      })
       .sampledBy(
         Bacon
           .fromEvent(this._preview, 'click')
-          .merge(openPathS))
-      .onValue((path: string) => {
+          .merge(presenter.openPathS))
+      .onValue(({selectedPath, newPath}) => {
+        const path = selectedPath || newPath
         if (path) {
           atom.workspace
             .open(path)

--- a/spec/presenter-spec.js
+++ b/spec/presenter-spec.js
@@ -82,6 +82,7 @@ describe('presenter', function () {
       listHeightP: jasmine.createSpy('listHeightP'),
       loadingProgressP: jasmine.createSpy('loadingProgressP'),
       loadingS: jasmine.createSpy('loadingS'),
+      newPathP: jasmine.createSpy('newPathP'),
       openPathS: jasmine.createSpy('openPathS'),
       paginationP: jasmine.createSpy('paginationP'),
       rowHeightP: jasmine.createSpy('rowHeightP'),
@@ -98,6 +99,7 @@ describe('presenter', function () {
     presenter.listHeightP.onValue(spies.listHeightP)
     presenter.loadingProgressP.onValue(spies.loadingProgressP)
     presenter.loadingS.onValue(spies.loadingS)
+    presenter.newPathP.onValue(spies.newPathP)
     presenter.openPathS.onValue(spies.openPathS)
     presenter.paginationP.onValue(spies.paginationP)
     presenter.rowHeightP.onValue(spies.rowHeightP)
@@ -129,6 +131,8 @@ describe('presenter', function () {
     let notes
 
     beforeEach(function () {
+      atom.config.set('textual-velocity.defaultExt', 'md')
+
       const notesPathP = NotesPath('/notes')
       buses.notesPathP.push(notesPathP)
       buses.loadingS.push()
@@ -307,7 +311,6 @@ describe('presenter', function () {
           expect(spies.openPathS).not.toHaveBeenCalled()
           buses.openFileS.push()
           expect(spies.openPathS).toHaveBeenCalled()
-          expect(spies.openPathS.mostRecentCall.args[0]).toMatch(/.+note 5.md/)
         })
 
         describe('when a note is deselected', function () {
@@ -326,25 +329,27 @@ describe('presenter', function () {
       })
 
       it('should open new note when there is no selected note', function () {
-        atom.config.set('textual-velocity.defaultExt', 'md')
         buses.selectedFilenameS.push('note 3.md') // preqrequisite for open
 
         expect(spies.openPathS).not.toHaveBeenCalled()
         buses.openFileS.push()
         expect(spies.openPathS).toHaveBeenCalled()
-        expect(spies.openPathS.mostRecentCall.args[0]).toEqual('/notes/note 3.md')
+        expect(spies.selectedPathP.mostRecentCall.args[0]).toEqual('/notes/note 3.md')
+        expect(spies.newPathP.mostRecentCall.args[0]).toEqual('/notes/STR.md', 'new path should have a default extension')
 
         buses.searchStrS.push('')
         buses.sifterResultP.push(
           newSifterResult({query: ''})
         )
         buses.selectedFilenameS.push(undefined)
-        buses.openFileS.push()
-        expect(spies.openPathS.mostRecentCall.args[0]).toEqual('/notes/untitled.md', 'should have default file extension')
+        buses.searchStrS.push('')
+        expect(spies.openPathS).toHaveBeenCalled()
+        expect(spies.newPathP.mostRecentCall.args[0]).toEqual('/notes/untitled.md', 'new path should have default file name + extension')
 
         atom.config.set('textual-velocity.defaultExt', '.txt')
-        buses.openFileS.push()
-        expect(spies.openPathS.mostRecentCall.args[0]).toEqual('/notes/untitled.txt', 'should have custom file extension')
+        buses.searchStrS.push('')
+        expect(spies.openPathS).toHaveBeenCalled()
+        expect(spies.newPathP.mostRecentCall.args[0]).toEqual('/notes/untitled.txt', 'new path should have custom file extension')
       })
     })
   })


### PR DESCRIPTION
Was caused by last bugfix #45.

Extracting new note path to a separate property instead of pushing it as part of the open stream, to make it easier to see state at the time of the sampling.