### PR TITLE
Fix file icons not working since file-icons v2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [keepachan
 
 #### Fixed
 - File icons not working since file-icons v2 release [#49](https://github.com/viddo/atom-textual-velocity/issues/49)
+- Rows not having consistent height
 
 ## [0.11.2] - 2016-12-05
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [keepachan
 #### Changed
 - Updated dependencies, fixed some flowtype complaints due to changes in new version
 
+#### Fixed
+- File icons not working since file-icons v2 release [#49](https://github.com/viddo/atom-textual-velocity/issues/49)
+
 ## [0.11.2] - 2016-12-05
 #### Fixed
 - Regression from previous fix #45, preventing new note from being created on <kbd>enter</kbd>

--- a/decls/textual-velocity/cell-type.js
+++ b/decls/textual-velocity/cell-type.js
@@ -1,4 +1,5 @@
 declare type CellType = {
+  className: string|void,
   editCellName: string | void,
   content: CellContentType
 }

--- a/decls/textual-velocity/column-type.js
+++ b/decls/textual-velocity/column-type.js
@@ -1,9 +1,10 @@
 declare type ColumnType = {
+  cellContent (params: CellContentParamsType): CellContentType,
+  className?: string,
+  description: string,
   editCellName?: string,
+  editCellStr?: (note: NoteType) => string,
   sortField: string,
   title: string,
-  description: string,
-  width: number,
-  editCellStr?: (note: NoteType) => string,
-  cellContent (params: CellContentParamsType): CellContentType
+  width: number
 }

--- a/decls/textual-velocity/edit-cell-type.js
+++ b/decls/textual-velocity/edit-cell-type.js
@@ -1,4 +1,5 @@
 declare type EditCellType = {
+  className?: string,
   editCellStr: string,
   content?: string
 }

--- a/decls/textual-velocity/service-v0-type.js
+++ b/decls/textual-velocity/service-v0-type.js
@@ -2,6 +2,7 @@ declare type ServiceV0Type = {
   registerColumns (...items: Array<ColumnType>): void,
   registerFields (...items: Array<FieldType>): void,
   registerFileReaders (...items: Array<FileReaderType>): void,
+  deregisterFileReaders (...items: Array<FileReaderType>): void,
   registerFileWriters (...items: Array<FileWriterType>): void,
   editCell (editCellName: string): void
 }

--- a/lib/columns/file-icon-column.js
+++ b/lib/columns/file-icon-column.js
@@ -20,13 +20,13 @@ export default class FileIconColumn {
     const {note} = params
     return {
       attrs: {
-        className: this._iconClassForBasename(params.path, note),
+        className: note.fileIcons || this._defaultFileIcons(params.path, note),
         'data-name': note.name + note.ext
       }
     }
   }
 
-  _iconClassForBasename (path: string, note: NoteType) {
+  _defaultFileIcons (path: string, note: NoteType) {
     // from https://github.com/atom/tree-view/blob/9dcc89fc0c8505528f393b5ebdd93616a8adbd68/lib/default-file-icons.coffee
     if (fs.isSymbolicLinkSync(path)) {
       return 'icon icon-file-symlink-file'

--- a/lib/columns/stats-date-column.js
+++ b/lib/columns/stats-date-column.js
@@ -4,6 +4,7 @@ import moment from 'moment'
 
 export default class StatsDateColumn {
 
+  className: string|void
   description: string
   sortField: string
   title: string
@@ -11,6 +12,7 @@ export default class StatsDateColumn {
   _notePropName: string
 
   constructor (params: {sortField: string, title: string, description: string, notePropName: string}) {
+    this.className = 'stats'
     this.description = params.description
     this.sortField = params.sortField
     this.title = params.title

--- a/lib/columns/summary-column.js
+++ b/lib/columns/summary-column.js
@@ -5,6 +5,7 @@ const HIGHLIGHT_PREVIEW_PADDING_LENGTH = 20 // characters
 
 export default class SummaryColumn {
 
+  className: string|void
   description: string
   editCellName: string | void
   editCellStr: void | (note: NoteType) => string
@@ -13,6 +14,7 @@ export default class SummaryColumn {
   width: number
 
   constructor (params: {editCellName: string, sortField: string}) {
+    this.className = 'summary'
     this.description = 'File name and content preview'
     this.editCellName = params.editCellName
     this.sortField = params.sortField

--- a/lib/file-readers/file-icons-reader.js
+++ b/lib/file-readers/file-icons-reader.js
@@ -1,0 +1,25 @@
+/* @flow */
+
+// File reader for integration with https://atom.io/packages/file-icons
+export default class FileIconsReader {
+
+  notePropName: string
+  _fileIconsService: {iconClassForPath: (path: string) => Array<string>}
+
+  constructor (fileIconsService: {iconClassForPath: (path: string) => Array<string>}) {
+    this._fileIconsService = fileIconsService
+    this.notePropName = 'fileIcons'
+  }
+
+  read (path: string, stats: FsStatsType, callback: NodeCallbackType) {
+    let classNames = this._fileIconsService.iconClassForPath(path)
+
+    if (classNames instanceof Array) {
+      classNames = classNames.join(' ')
+    } else if (typeof classNames !== 'string') {
+      classNames = null
+    }
+
+    callback(null, classNames)
+  }
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,6 +8,7 @@ import renameNote from './service-consumers/rename-note'
 import defaults from './service-consumers/defaults'
 import defaultConfig from './default-config'
 import NotesCache from './notes-cache'
+import FileIconsReader from './file-readers/file-icons-reader'
 
 const RENAME_CELL_NAME = 'rename'
 
@@ -26,6 +27,21 @@ export function activate () {
   )
 
   startSession()
+}
+
+// Integration with https://atom.io/packages/file-icons
+export function consumeFileIconsService (fileIconsService: any) {
+  const fileIconsReader = new FileIconsReader(fileIconsService)
+
+  if (serviceV0) {
+    serviceV0.registerFileReaders(fileIconsReader)
+  }
+
+  return new Disposables(() => {
+    if (serviceV0) {
+      serviceV0.deregisterFileReaders(fileIconsReader)
+    }
+  })
 }
 
 export function provideServiceV0 () {

--- a/lib/path-watcher-factory.js
+++ b/lib/path-watcher-factory.js
@@ -75,7 +75,7 @@ export default class PathWatcherFactory {
                 value: null
               }
               return Bacon
-                .fromNodeCallback(fileReader.read, notesPath.fullPath(filename), fileStats)
+                .fromNodeCallback(fileReader.read.bind(fileReader), notesPath.fullPath(filename), fileStats)
                 .map(value => {
                   readResult.value = value === undefined ? null : value // make sure value cannot be undefined
                   return readResult

--- a/lib/presenter.js
+++ b/lib/presenter.js
@@ -113,6 +113,7 @@ export default class Presenter {
                     }
                   } else {
                     return {
+                      className: column.className || '',
                       content: column.cellContent(contentParams),
                       editCellName: column.editCellName && column.editCellName
                     }

--- a/lib/prop-wrapper.js
+++ b/lib/prop-wrapper.js
@@ -7,10 +7,12 @@ export default class PropWrapper {
   prop: Bacon.Property
 
   _addBus: Bacon.Bus
+  _removeBus: Bacon.Bus
   _unsubscribe: Function
 
   constructor () {
     this._addBus = new Bacon.Bus()
+    this._removeBus = new Bacon.Bus()
 
     this.prop = Bacon.update(
       [],
@@ -21,6 +23,9 @@ export default class PropWrapper {
           list.splice(newItem.position, 0, newItem)
         }
         return list
+      },
+      [this._removeBus], (list, itemToRemove) => {
+        return list.filter(item => item !== itemToRemove)
       })
 
     this._unsubscribe = this.prop.onValue(() => {}) // no-op, for values to work w/o subscribers
@@ -30,8 +35,13 @@ export default class PropWrapper {
     this._addBus.push(newItem)
   }
 
+  remove (itemToRemove: Object) {
+    this._removeBus.push(itemToRemove)
+  }
+
   dispose () {
     this._unsubscribe()
     this._addBus.end()
+    this._removeBus.end()
   }
 }

--- a/lib/react/cell.js
+++ b/lib/react/cell.js
@@ -5,12 +5,13 @@ import {React} from 'react-for-atom'
 export default React.createClass({
 
   propTypes: {
+    className: React.PropTypes.string,
     content: React.PropTypes.any,
     onClick: React.PropTypes.func
   },
 
   render () {
-    return <td onClick={() => this.props.onClick()}>
+    return <td className={this.props.className} onClick={() => this.props.onClick()}>
       {this._renderContent(this.props.content)}
     </td>
   },

--- a/lib/service-consumers/nv-tags.js
+++ b/lib/service-consumers/nv-tags.js
@@ -89,6 +89,7 @@ module.exports = {
     service.registerColumns({
       title: 'NV tags',
       description: 'NV Tags',
+      className: 'nv-tags',
       position: 2, // after Summary
       sortField: FIELD_NAME,
       editCellName: FILE_PROP_NAME,

--- a/lib/service.js
+++ b/lib/service.js
@@ -55,6 +55,10 @@ export default class Service {
     this._fileReaders.add(fileReader)
   }
 
+  removeFileReader (fileReader: FileReaderType) {
+    this._fileReaders.remove(fileReader)
+  }
+
   addFileWriter (fileWriter: FileWriterType) {
     if (typeof fileWriter !== 'object') return logError('fileWriter object is required', fileWriter)
     if (typeof fileWriter.editCellName !== 'string') return logError('fileWriter.editCellName string is required', fileWriter)
@@ -77,6 +81,10 @@ export default class Service {
 
       registerFileReaders (...items: Array<FileReaderType>) {
         items.forEach(item => self.addFileReader(item))
+      },
+
+      deregisterFileReaders (...items: Array<FileReaderType>) {
+        items.forEach(item => self.removeFileReader(item))
       },
 
       registerFileWriters (...items: Array<FileWriterType>) {

--- a/lib/view-ctrl.js
+++ b/lib/view-ctrl.js
@@ -198,7 +198,7 @@ export default class ViewCtrl {
                             abort={() => this._abortEditCellBus.push()} />)
                       } else {
                         return (
-                          <Cell key={i} content={cell.content} onClick={() => {
+                          <Cell key={i} className={cell.className} content={cell.content} onClick={() => {
                             this._clickCellBus.push({filename: filename, cell: cell})
                           }} />)
                       }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,13 @@
       }
     }
   },
+  "consumedServices": {
+    "atom.file-icons": {
+      "versions": {
+        "^1.0.0": "consumeFileIconsService"
+      }
+    }
+  },
   "dependencies": {
     "baconjs": "0.7.89",
     "chokidar": "1.6.1",

--- a/spec/columns/file-icon-column-spec.js
+++ b/spec/columns/file-icon-column-spec.js
@@ -23,6 +23,7 @@ describe('columns/file-icon-column', function () {
       note = {
         id: '',
         name: 'markdown',
+        fileIcons: null,
         ext: '.md'
       }
       cellContent = column.cellContent({note: note, path: path})
@@ -33,6 +34,21 @@ describe('columns/file-icon-column', function () {
       expect(cellContent.attrs).toEqual({
         className: 'icon icon-file-text',
         'data-name': 'markdown.md'
+      })
+    })
+
+    describe('when note.fileIcons are available', function () {
+      beforeEach(function () {
+        note.fileIcons = 'icon-file-text medium-blue'
+        cellContent = column.cellContent({note: note, path: path})
+      })
+
+      it('should utilize file icons instead', function () {
+        expect(cellContent).toEqual(jasmine.any(Object), 'title')
+        expect(cellContent.attrs).toEqual({
+          className: 'icon-file-text medium-blue',
+          'data-name': 'markdown.md'
+        })
       })
     })
   })

--- a/spec/presenter-spec.js
+++ b/spec/presenter-spec.js
@@ -65,6 +65,7 @@ describe('presenter', function () {
       cellContent: (params: CellContentParamsType) => params.note.name
     }
     extColumn = {
+      className: 'file-icons',
       sortField: 'ext',
       title: 'File extension',
       width: 10,
@@ -193,8 +194,8 @@ describe('presenter', function () {
         expect(row.selected).toBe(false)
         expect(row.cells).toEqual(jasmine.any(Array))
         expect(spies.rowsS.mostRecentCall.args[0][0].cells).toEqual([
-          {content: 'note 0', editCellName: 'name'},
-          {content: '.md', editCellName: undefined}
+          {className: '', content: 'note 0', editCellName: 'name'},
+          {className: 'file-icons', content: '.md', editCellName: undefined}
         ])
       })
     })
@@ -231,8 +232,8 @@ describe('presenter', function () {
           jasmine.objectContaining({
             id: jasmine.any(String),
             cells: [
-              {content: 'note 3', editCellName: 'name'},
-              {content: '.md', editCellName: undefined}
+              {className: '', content: 'note 3', editCellName: 'name'},
+              {className: 'file-icons', content: '.md', editCellName: undefined}
             ]
           })
         )
@@ -264,9 +265,9 @@ describe('presenter', function () {
           expect(spies.rowsS.mostRecentCall.args[0]).toEqual(jasmine.any(Array))
           expect(spies.rowsS.mostRecentCall.args[0].length).toEqual(3)
           expect(spies.rowsS.mostRecentCall.args[0].map(x => x.cells)).toEqual([
-            [{content: 'note 7', editCellName: 'name'}, {content: '.md', editCellName: undefined}],
-            [{content: 'note 8', editCellName: 'name'}, {content: '.md', editCellName: undefined}],
-            [{content: 'note 9', editCellName: 'name'}, {content: '.md', editCellName: undefined}]
+            [{className: '', content: 'note 7', editCellName: 'name'}, {className: 'file-icons', content: '.md', editCellName: undefined}],
+            [{className: '', content: 'note 8', editCellName: 'name'}, {className: 'file-icons', content: '.md', editCellName: undefined}],
+            [{className: '', content: 'note 9', editCellName: 'name'}, {className: 'file-icons', content: '.md', editCellName: undefined}]
           ])
         })
       })

--- a/spec/prop-wrapper-spec.js
+++ b/spec/prop-wrapper-spec.js
@@ -15,11 +15,11 @@ describe('prop-wrapper', function () {
     propWrapper.dispose()
   })
 
-  it('should have ', function () {
+  it('should have empty list by default', function () {
     expect(propSpy).toHaveBeenCalledWith([])
   })
 
-  it('should update prop on adding an item', function () {
+  it('should update prop on adding/removing item', function () {
     testObj = {}
     propWrapper.add(testObj)
     expect(propSpy).toHaveBeenCalledWith([testObj])
@@ -27,5 +27,8 @@ describe('prop-wrapper', function () {
     testObj2 = {}
     propWrapper.add(testObj2)
     expect(propSpy).toHaveBeenCalledWith([testObj, testObj2])
+
+    propWrapper.remove(testObj)
+    expect(propSpy).toHaveBeenCalledWith([testObj2])
   })
 })

--- a/spec/service-consumers/rename-note-spec.js
+++ b/spec/service-consumers/rename-note-spec.js
@@ -14,6 +14,7 @@ describe('service-consumers/rename-note', function () {
         registerColumns: jasmine.createSpy('registerColumns'),
         registerFields: jasmine.createSpy('registerFields'),
         registerFileReaders: jasmine.createSpy('registerFileReaders'),
+        deregisterFileReaders: jasmine.createSpy('deregisterFileReaders'),
         registerFileWriters: jasmine.createSpy('registerFileWriters'),
         editCell: jasmine.createSpy('editCell')
       }

--- a/spec/service-spec.js
+++ b/spec/service-spec.js
@@ -101,8 +101,10 @@ describe('service', function () {
     })
 
     describe('.registerFileReaders', function () {
+      let fileReader
+
       it('should register a new file reader', function () {
-        const fileReader = {
+        fileReader = {
           notePropName: 'test',
           read: (path, callback) => {}
         }
@@ -111,6 +113,13 @@ describe('service', function () {
         expect(spies.fieldsP).not.toHaveBeenCalled()
         expect(spies.fileReadersP).toHaveBeenCalledWith([fileReader])
         expect(spies.fileWritersP).not.toHaveBeenCalled()
+      })
+
+      describe('.deregisterFileReaders', function () {
+        it('should deregister an existing file reader', function () {
+          v0.deregisterFileReaders(fileReader)
+          expect(spies.fileReadersP).toHaveBeenCalledWith([])
+        })
       })
     })
 

--- a/styles/textual-velocity.less
+++ b/styles/textual-velocity.less
@@ -60,7 +60,6 @@
     width: 100%;
   }
   tr {
-    height: @component-line-height;
     &:nth-child(odd) { background-color: @tree-view-background-color }
     &:nth-child(even) { background-color: lighten(@tree-view-background-color, 2%) }
   }
@@ -79,7 +78,8 @@
     color: @text-color-selected;
   }
   td, th {
-    padding: @component-icon-padding;
+    padding-left: @component-icon-padding;
+    padding-right: @component-icon-padding;
     max-width: 0; // required for overflow to work
     overflow: hidden;
     text-overflow: ellipsis;
@@ -91,6 +91,8 @@
     }
   }
   th {
+    padding-top: @component-icon-padding;
+    padding-bottom: @component-icon-padding;
     color: @text-color-subtle;
     cursor: pointer;
     &.is-selected {
@@ -102,6 +104,11 @@
     &.edit-cell-str {
       display: table-cell;
       padding: 0;
+    }
+    &.summary,
+    &.stats {
+      padding-top: @component-icon-padding;
+      padding-bottom: @component-icon-padding;
     }
   }
   .only-for-column-widths {


### PR DESCRIPTION
Fixes #49 

Nowadays one has to [consume the file-icons service](https://github.com/DanBrooker/file-icons/blob/e537dacc23e798b3d3e432d90e344134e28e8d69/package.json#L37-L41) to get a file's class name(s). This call is more costly than to do some primitive string checks (as previously done), so implemented it as a [file-reader](https://github.com/viddo/atom-textual-velocity/tree/17c89d137493240daa091d0b7708f8e77d34712b/lib/file-readers) instead to have the values read and cached. The file-icons column was changed to utilize the new field, and fall back on the default icons only if not available.

Also fixed rows to have consistent size, which became apparent after using the new file icons.