### PR TITLE
Fix eslint from being killed on Travis

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,3 @@
-decls/
-flow-typed/
-lib/flow-types/
-node_modules/
-spec/
+.*
+**/*.*
+!lib/**/*.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,12 @@ module.exports = {
     jasmine: true,
     node: true
   },
-  extends: ["eslint:recommended", "prettier", "plugin:react/recommended"],
+  extends: [
+    "eslint:recommended",
+    "prettier",
+    "plugin:react/recommended",
+    "plugin:flowtype/recommended"
+  ],
   parser: "babel-eslint",
   parserOptions: {
     ecmaFeatures: {
@@ -16,9 +21,7 @@ module.exports = {
   plugins: ["prettier", "flowtype", "react"],
   rules: {
     "no-console": "off",
-    "prettier/prettier": "error",
-    "flowtype/define-flow-type": 1,
-    "flowtype/use-flow-type": 1
+    "prettier/prettier": "error"
   },
   settings: {
     flowtype: {

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ os:
 - osx
 script:
 - "./build-package.sh"
-- "./node_modules/.bin/eslint lib"
+- "./eslint.sh"
 - "./node_modules/.bin/flow"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ os:
 - linux
 - osx
 script:
-- curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+- curl -s -O https://raw.githubusercontent.com/viddo/atom-textual-velocity/fix-killed-eslint/build-package.sh
 - chmod u+x build-package.sh
 - "./build-package.sh"
 - "./node_modules/.bin/flow"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,8 @@ os:
 - linux
 - osx
 script:
-- curl -s -O https://raw.githubusercontent.com/viddo/atom-textual-velocity/fix-killed-eslint/build-package.sh
-- chmod u+x build-package.sh
 - "./build-package.sh"
+- "./node_modules/.bin/eslint lib"
 - "./node_modules/.bin/flow"
 notifications:
   email: false

--- a/build-package.sh
+++ b/build-package.sh
@@ -152,10 +152,10 @@ if has_linter "coffeelint"; then
   fi
 fi
 
-if has_linter "eslint"; then
+if has_linter "skip eslint"; then
   if [ -d ./lib ]; then
     echo "Linting package using eslint..."
-    ./node_modules/.bin/eslint lib --debug
+    ./node_modules/.bin/eslint lib
     rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
   fi
   if [ -d ./spec ]; then

--- a/build-package.sh
+++ b/build-package.sh
@@ -1,0 +1,196 @@
+#!/bin/sh
+
+ATOM_CHANNEL="${ATOM_CHANNEL:=stable}"
+
+echo "Downloading latest Atom release on the ${ATOM_CHANNEL} channel..."
+if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+  curl -s -L "https://atom.io/download/mac?channel=${ATOM_CHANNEL}" \
+    -H 'Accept: application/octet-stream' \
+    -o "atom.zip"
+  mkdir atom
+  unzip -q atom.zip -d atom
+  if [ "${ATOM_CHANNEL}" = "stable" ] || [ "${ATOM_CHANNEL}" = "dev" ]; then
+    export ATOM_APP_NAME="Atom.app"
+    export ATOM_SCRIPT_NAME="atom.sh"
+    export ATOM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh"
+  else
+    export ATOM_APP_NAME="Atom ${ATOM_CHANNEL}.app"
+    export ATOM_SCRIPT_NAME="atom-${ATOM_CHANNEL}"
+    export ATOM_SCRIPT_PATH="./atom-${ATOM_CHANNEL}"
+    ln -s "./atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh" "${ATOM_SCRIPT_PATH}"
+  fi
+  export ATOM_PATH="./atom"
+  export APM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
+  export NPM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/npm"
+  export PATH="${PATH}:${TRAVIS_BUILD_DIR}/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin"
+elif [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+  curl -s -L "https://atom.io/download/deb?channel=${ATOM_CHANNEL}" \
+    -H 'Accept: application/octet-stream' \
+    -o "atom-amd64.deb"
+  /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
+  export DISPLAY=":99"
+  dpkg-deb -x atom-amd64.deb "${HOME}/atom"
+  if [ "${ATOM_CHANNEL}" = "stable" ] || [ "${ATOM_CHANNEL}" = "dev" ]; then
+    export ATOM_SCRIPT_NAME="atom"
+    export APM_SCRIPT_NAME="apm"
+  else
+    export ATOM_SCRIPT_NAME="atom-${ATOM_CHANNEL}"
+    export APM_SCRIPT_NAME="apm-${ATOM_CHANNEL}"
+  fi
+  export ATOM_SCRIPT_PATH="${HOME}/atom/usr/bin/${ATOM_SCRIPT_NAME}"
+  export APM_SCRIPT_PATH="${HOME}/atom/usr/bin/${APM_SCRIPT_NAME}"
+  export NPM_SCRIPT_PATH="${HOME}/atom/usr/share/${ATOM_SCRIPT_NAME}/resources/app/apm/node_modules/.bin/npm"
+elif [ "${CIRCLECI}" = "true" ]; then
+  case "${CIRCLE_BUILD_IMAGE}" in
+    ubuntu*)
+      curl -s -L "https://atom.io/download/deb?channel=${ATOM_CHANNEL}" \
+        -H 'Accept: application/octet-stream' \
+        -o "atom-amd64.deb"
+      sudo dpkg --install atom-amd64.deb || true
+      sudo apt-get update
+      sudo apt-get --fix-broken --assume-yes --quiet install
+      if [ "${ATOM_CHANNEL}" = "stable" ] || [ "${ATOM_CHANNEL}" = "dev" ]; then
+        export ATOM_SCRIPT_PATH="atom"
+        export APM_SCRIPT_PATH="apm"
+      else
+        export ATOM_SCRIPT_PATH="atom-${ATOM_CHANNEL}"
+        export APM_SCRIPT_PATH="apm-${ATOM_CHANNEL}"
+      fi
+      export NPM_SCRIPT_PATH="/usr/share/atom/resources/app/apm/node_modules/.bin/npm"
+      ;;
+    osx)
+      curl -s -L "https://atom.io/download/mac?channel=${ATOM_CHANNEL}" \
+        -H 'Accept: application/octet-stream' \
+        -o "atom.zip"
+      mkdir -p /tmp/atom
+      unzip -q atom.zip -d /tmp/atom
+      if [ "${ATOM_CHANNEL}" = "stable" ] || [ "${ATOM_CHANNEL}" = "dev" ]; then
+        export ATOM_APP_NAME="Atom.app"
+        export ATOM_SCRIPT_NAME="atom.sh"
+        export ATOM_SCRIPT_PATH="/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh"
+      else
+        export ATOM_APP_NAME="Atom ${ATOM_CHANNEL}.app"
+        export ATOM_SCRIPT_NAME="atom-${ATOM_CHANNEL}"
+        export ATOM_SCRIPT_PATH="/tmp/atom-${ATOM_CHANNEL}"
+        ln -s "/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh" "${ATOM_SCRIPT_PATH}"
+      fi
+      export ATOM_PATH="/tmp/atom"
+      export APM_SCRIPT_PATH="/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
+      export NPM_SCRIPT_PATH="/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/npm"
+      export PATH="${PATH}:${TRAVIS_BUILD_DIR}/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin"
+
+      # Clear screen saver
+      osascript -e 'tell application "System Events" to keystroke "x"'
+      ;;
+    *)
+      echo "Unsupported CircleCI OS: ${CIRCLE_BUILD_IMAGE}" >&2
+      exit 1
+      ;;
+    esac
+else
+  echo "Unknown CI environment, exiting!"
+  exit 1
+fi
+
+echo "Using Atom version:"
+"${ATOM_SCRIPT_PATH}" -v
+echo "Using APM version:"
+"${APM_SCRIPT_PATH}" -v
+
+echo "Downloading package dependencies..."
+"${APM_SCRIPT_PATH}" clean
+
+if [ "${ATOM_LINT_WITH_BUNDLED_NODE:=true}" = "true" ]; then
+  "${APM_SCRIPT_PATH}" install
+
+  # Override the PATH to put the Node bundled with APM first
+  if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+    export PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/bin:${PATH}"
+  elif [ "${CIRCLECI}" = "true" ] && [ "${CIRCLE_BUILD_IMAGE}" = "osx" ]; then
+    export PATH="/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/bin:${PATH}"
+  elif [ "${CIRCLECI}" = "true" ]; then
+    # Since CircleCI/Linux is a fully installed environment, we use the system path to apm
+    export PATH="/usr/share/atom/resources/app/apm/bin:${PATH}"
+  else
+    export PATH="${HOME}/atom/usr/share/${ATOM_SCRIPT_NAME}/resources/app/apm/bin:${PATH}"
+  fi
+else
+  export NPM_SCRIPT_PATH="npm"
+  "${APM_SCRIPT_PATH}" install --production
+
+  # Use the system NPM to install the devDependencies
+  echo "Using Node version:"
+  node --version
+  echo "Using NPM version:"
+  npm --version
+  echo "Installing remaining dependencies..."
+  npm install
+fi
+
+if [ -n "${APM_TEST_PACKAGES}" ]; then
+  echo "Installing atom package dependencies..."
+  for pack in ${APM_TEST_PACKAGES}; do
+    "${APM_SCRIPT_PATH}" install "${pack}"
+  done
+fi
+
+has_linter() {
+  linter_module_path="$( ${NPM_SCRIPT_PATH} ls --parseable --dev --depth=0 "$1" 2> /dev/null )"
+  [ -n "${linter_module_path}" ]
+}
+
+if has_linter "coffeelint"; then
+  if [ -d ./lib ]; then
+    echo "Linting package using coffeelint..."
+    ./node_modules/.bin/coffeelint lib
+    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+  fi
+  if [ -d ./spec ]; then
+    echo "Linting package specs using coffeelint..."
+    ./node_modules/.bin/coffeelint spec
+    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+  fi
+fi
+
+if has_linter "eslint"; then
+  if [ -d ./lib ]; then
+    echo "Linting package using eslint..."
+    ./node_modules/.bin/eslint lib --debug
+    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+  fi
+  if [ -d ./spec ]; then
+    echo "Linting package specs using eslint..."
+    ./node_modules/.bin/eslint spec
+    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+  fi
+fi
+
+if has_linter "standard"; then
+  if [ -d ./lib ]; then
+    echo "Linting package using standard..."
+    ./node_modules/.bin/standard "lib/**/*.js"
+    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+  fi
+  if [ -d ./spec ]; then
+    echo "Linting package specs using standard..."
+    ./node_modules/.bin/standard "spec/**/*.js"
+    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+  fi
+  if [ -d ./test ]; then
+    echo "Linting package tests using standard..."
+    ./node_modules/.bin/standard "test/**/*.js"
+    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+  fi
+fi
+
+if [ -d ./spec ]; then
+  echo "Running specs..."
+  "${ATOM_SCRIPT_PATH}" --test spec
+elif [ -d ./test ]; then
+  echo "Running specs..."
+  "${ATOM_SCRIPT_PATH}" --test test
+else
+  echo "Missing spec folder! Please consider adding a test suite in './spec' or in './test'"
+  exit 0
+fi
+exit

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,7 @@
 test:
   override:
-    - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
-    - chmod u+x build-package.sh
     - ./build-package.sh
+    - './node_modules/.bin/eslint lib'
     - './node_modules/.bin/flow'
 
 dependencies:

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,8 @@
 test:
   override:
-    - ./build-package.sh
-    - './node_modules/.bin/eslint lib'
-    - './node_modules/.bin/flow'
+    - "./build-package.sh"
+    - "./eslint.sh"
+    - "./node_modules/.bin/flow"
 
 dependencies:
   override:

--- a/eslint.sh
+++ b/eslint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# taken from build-package.sh, since it appears to cause OOM on Travis CI
+echo "Linting package using eslint..."
+./node_modules/.bin/eslint lib
+rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "lint-prettier": "prettier --list-different \"lib/**/*.js\"",
     "lint-prettier-write": "prettier --write \"lib/**/*.js\"",
     "test": "npm run flow && npm run lint && apm test",
-    "update-flow-typed": "flow-typed install --overwrite"
+    "update-flow-typed": "flow-typed install --overwrite",
+    "update-build-package": "curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh"
   },
   "lint-staged": {
     "lib/**/*.js": [

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   "scripts": {
     "precommit": "lint-staged",
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
-    "lint": "eslint lib",
+    "lint": "./build-package-eslint.sh",
     "lint-prettier": "prettier --list-different \"lib/**/*.js\"",
     "lint-prettier-write": "prettier --write \"lib/**/*.js\"",
     "test": "npm run flow && npm run lint && apm test",


### PR DESCRIPTION
ESLint fails on Linux (but works on Mac):
```
The command "chmod u+x build-package.sh" exited with 0.
92.29s$ ./build-package.sh
Downloading latest Atom release on the stable channel...
Using Atom version:
Atom    : 1.23.3
Electron: 1.6.15
Chrome  : 56.0.2924.87
Node    : 7.4.0
Using APM version:
apm  1.18.12
npm  3.10.10
node 6.9.5 x64
atom 1.23.3
python 2.7.6
git 2.15.1
Downloading package dependencies...
Installing modules ✓
Linting package using eslint...
Killed

The command "./build-package.sh" exited with 137.
```

From https://stackoverflow.com/a/1041309
> 137=128+9, which means some other process has sent you a signal 9, which is SIGKILL. I.e. the other script kills yours, that's what it looks like.

As discussed there, most likely a kill signal due to OOM.

Running `eslint` separately from `build-package.sh` seems to do the trick.