### PR TITLE
Disable xattrs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [keepachan
 ## [unreleased]
 #### Fixed
 - _Last updated_ column not display last change
+- Create notes dir if it doesn't exist
+- Handle edge-case of empty notes dir
 
 #### Changed
 - Disabled xattrs support by default, can be enabled by package setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,21 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [keepachan
 
 
 ## [unreleased]
+#### Fixed
+- _Last updated_ column not display last change
+
 #### Changed
-Internal refactoring:
-- Separate React code into presentational and container components
-- Use default recommended ESlint rules + fix offending code
-- Update flowtyped definitions
-- Flowtype all code
-- Change filename convention, to match content
-- Move specs next to source files
-- Remove unused service implementation
+- Disabled xattrs support by default, can be enabled by package setting
+  - Appears to crash Atom as of v1.28+
+- Internal refactorings:
+  - Separate React code into presentational and container components
+  - Use default recommended ESlint rules + fix offending code
+  - Update flowtyped definitions
+  - Flowtype all code
+  - Change filename convention, to match content
+  - Move specs next to source files
+  - Remove unused service implementation
+  - Updated all internal deps to latest versions
 
 ## [0.18.0] - 2017-11-20
 #### Changed

--- a/lib/Columns.js
+++ b/lib/Columns.js
@@ -20,8 +20,8 @@ columns.push(
   new StatsDateColumn({
     title: "Last updated",
     description: "Last updated date",
-    notePropName: "lastupdate",
-    sortField: "lastupdate"
+    notePropName: "mtime",
+    sortField: "mtime"
   }),
   new StatsDateColumn({
     title: "Created",

--- a/lib/NVtags.js
+++ b/lib/NVtags.js
@@ -10,6 +10,9 @@ let unsupportedError = null;
 const XATTR_KEY = "com.apple.metadata:kMDItemOMUserTags";
 
 try {
+  if (!atom.config.get("textual-velocity.xattrs")) {
+    throw new Error("xattrs disabled by config: textual-velocity.xattrs");
+  }
   // Due to being optionalDependencies they might not exist, if that's the case do nothing and just return
   bplist = require("bplist");
   xattr = require("fs-xattr");

--- a/lib/NoteFields.js
+++ b/lib/NoteFields.js
@@ -18,7 +18,7 @@ const noteFields: INoteField[] = [
     parsedPathPropName: "ext"
   }),
   new StatsDateNoteField({
-    notePropName: "lastupdate",
+    notePropName: "mtime",
     statsPropName: "mtime"
   }),
   new StatsDateNoteField({

--- a/lib/NotesCache.js
+++ b/lib/NotesCache.js
@@ -2,8 +2,10 @@
 
 import BSON from "bson";
 import fs from "fs";
-import Path from "path";
+import path from "path";
 import Disposables from "./Disposables";
+import { showWarningNotification } from "./showWarningNotification";
+
 import type { Notes } from "./flow-types/Note";
 
 export const CACHE_FILENAME = ".textual-velocity-cache";
@@ -48,22 +50,24 @@ export default class NotesCache {
       .save(atom.getStateKey(LEGACY_CUSTOM_STATE_KEY), {})
       .catch(() => {});
 
-    const path = Path.join(this._dir, CACHE_FILENAME);
+    const cachePath = path.join(this._dir, CACHE_FILENAME);
     const bson = new BSON();
     try {
-      return bson.deserialize(fs.readFileSync(path));
-    } catch (err) {
-      console.warn("textual-velocity: could not load cached notes:", err);
+      return fs.existsSync(cachePath)
+        ? bson.deserialize(fs.readFileSync(cachePath))
+        : {};
+    } catch (error) {
+      showWarningNotification("Failed to load notes cache", error);
       return {};
     }
   }
 
   save(notes: Notes) {
-    const path = Path.join(this._dir, CACHE_FILENAME);
+    const cachePath = path.join(this._dir, CACHE_FILENAME);
 
     if (this._skipSave) {
       try {
-        fs.unlinkSync(path);
+        fs.unlinkSync(cachePath);
       } catch (err) {
         console.warn("textual-velocity: could not clear notes cache:", err);
       }
@@ -71,7 +75,7 @@ export default class NotesCache {
       const bson = new BSON();
       try {
         const data = bson.serialize(notes);
-        fs.writeFileSync(path, data);
+        fs.writeFileSync(cachePath, data);
       } catch (err) {
         console.warn("textual-velocity: could not cache notes:", err);
       }

--- a/lib/columns/StatsDateColumn-spec.js
+++ b/lib/columns/StatsDateColumn-spec.js
@@ -9,7 +9,7 @@ describe("columns/StatsDateColumn", function() {
   beforeEach(function() {
     column = new StatsDateColumn({
       description: "",
-      sortField: "lastupdate",
+      sortField: "mtime",
       title: "Created date",
       notePropName: "birthtime"
     });
@@ -17,7 +17,7 @@ describe("columns/StatsDateColumn", function() {
 
   describe(".sortField", function() {
     it("should return sort field", function() {
-      expect(column.sortField).toEqual("lastupdate");
+      expect(column.sortField).toEqual("mtime");
     });
   });
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -72,5 +72,11 @@ export const defaultConfig = (cfg => {
     default: 20,
     minimum: 8,
     maximum: 80
+  },
+  xattrs: {
+    description:
+      "xattrs support - note that this appear to be unstable on Atom v1.28+",
+    type: "boolean",
+    default: false
   }
 });

--- a/lib/epics/fileReadsEpic.js
+++ b/lib/epics/fileReadsEpic.js
@@ -14,6 +14,7 @@ import { ofType } from "redux-observable";
 import * as A from "../actions";
 import fileReaders from "../FileReaders";
 import takeUntilDispose from "../takeUntilDispose";
+import { showWarningNotification } from "../showWarningNotification";
 
 import type { Action } from "../actions";
 import type { FileReadResult, RawFile } from "../flow-types/File";
@@ -136,12 +137,7 @@ function readFilesAsObservable(
           return A.fileRead(result);
         }),
         catchError(error => {
-          const message = `Textual-Velocity: Failed to read file ${filePath}`;
-          atom.notifications.addWarning(message, {
-            detail: error.message,
-            dismissable: true
-          });
-
+          showWarningNotification(`Failed to read file ${filePath}`, error);
           return of(
             A.fileReadFailed({
               filename: rawFile.filename,

--- a/lib/epics/pathWatcherEpic.js
+++ b/lib/epics/pathWatcherEpic.js
@@ -6,10 +6,12 @@ import path from "path";
 import { bindNodeCallback, empty, from, fromEventPattern, of } from "rxjs";
 import { catchError, filter, mergeMap, map } from "rxjs/operators";
 import * as A from "../actions";
-import type { Action } from "../actions";
-import type { State } from "../flow-types/State";
 import NotesFileFilter from "../NotesFileFilter";
 import takeUntilDispose from "../takeUntilDispose";
+import { showWarningNotification } from "../showWarningNotification";
+
+import type { Action } from "../actions";
+import type { State } from "../flow-types/State";
 
 export default function pathWatcherEpic(
   action$: rxjs$Observable<Action>,
@@ -60,7 +62,7 @@ export default function pathWatcherEpic(
 
 function newEventPatternHandlers(dir: string) {
   let watcher;
-  let unsubscribeOnDidError;
+  let onWatcherDidError;
 
   const addHandler = handler => {
     // necessary to comply with fromEventPattern's params signature,
@@ -69,12 +71,8 @@ function newEventPatternHandlers(dir: string) {
       const options = {}; // there are no options, for now just a placeholder for the future
       watcher = await watchPath(dir, options, handler);
 
-      unsubscribeOnDidError = watcher.onDidError(error => {
-        const message = `Textual-Velocity: An error occured on watched notes path ${dir}`;
-        atom.notifications.addWarning(message, {
-          detail: error.message,
-          dismissable: true
-        });
+      onWatcherDidError = watcher.onDidError(error => {
+        showWarningNotification(`Watched notes path ${dir} failed`, error);
       });
 
       if (global.setProcessInTesting) {
@@ -89,8 +87,8 @@ function newEventPatternHandlers(dir: string) {
       if (watcher) {
         await watcher.dispose();
       }
-      if (unsubscribeOnDidError) {
-        unsubscribeOnDidError.dispose();
+      if (onWatcherDidError) {
+        onWatcherDidError.dispose();
       }
     };
     innerHandler();

--- a/lib/epics/readDirEpic.js
+++ b/lib/epics/readDirEpic.js
@@ -2,7 +2,7 @@
 
 import fs from "fs";
 import path from "path";
-import { bindNodeCallback, empty, from, merge, Subject } from "rxjs";
+import { bindNodeCallback, empty, from, merge, of, Subject } from "rxjs";
 import {
   buffer,
   catchError,
@@ -40,9 +40,9 @@ export default function readDirEpic(
     mergeMap(filenames => from(filenames)),
     filter(filename => notesFileFilter.isAccepted(filename)),
     mergeMap(filename => {
-      const statAsObservable = bindNodeCallback(fs.stat);
       const filePath = path.join(dir, filename);
 
+      const statAsObservable = bindNodeCallback(fs.stat);
       return statAsObservable(filePath).pipe(
         map(stats => {
           if (stats.isFile()) {
@@ -72,10 +72,17 @@ export default function readDirEpic(
     rawFile$.pipe(map(() => A.fileFound())),
 
     rawFile$.pipe(
-      buffer(rawFile$.pipe(last())),
-      map(rawFiles => {
-        return A.readDirDone(rawFiles);
-      }),
+      buffer(
+        rawFile$.pipe(
+          last(),
+          catchError(() => {
+            // If there are no rawFiles last will yield an EmptyError,
+            // yield an empty list instead of erroring out
+            return of([]);
+          })
+        )
+      ),
+      map(rawFiles => A.readDirDone(rawFiles)),
       take(1)
     )
   ).pipe(

--- a/lib/epics/readDirEpic.js
+++ b/lib/epics/readDirEpic.js
@@ -15,10 +15,12 @@ import {
   take
 } from "rxjs/operators";
 import * as A from "../actions";
-import type { Action } from "../actions";
-import type { State } from "../flow-types/State";
 import NotesFileFilter from "../NotesFileFilter";
 import takeUntilDispose from "../takeUntilDispose";
+import { showWarningNotification } from "../showWarningNotification";
+
+import type { Action } from "../actions";
+import type { State } from "../flow-types/State";
 
 export default function readDirEpic(
   action$: rxjs$Observable<Action>,
@@ -30,11 +32,7 @@ export default function readDirEpic(
   const readdirAsObservable = bindNodeCallback(fs.readdir);
   const rawFile$ = readdirAsObservable(dir).pipe(
     catchError(error => {
-      const message = `Textual-Velocity: Failed to read directory ${dir}`;
-      atom.notifications.addWarning(message, {
-        detail: error.message,
-        dismissable: true
-      });
+      showWarningNotification(`Failed to read directory ${dir}`, error);
       return empty();
     }),
     mergeMap(filenames => from(filenames)),
@@ -53,11 +51,7 @@ export default function readDirEpic(
           }
         }),
         catchError(error => {
-          const message = `Textual-Velocity: Failed to stat file ${filePath}`;
-          atom.notifications.addWarning(message, {
-            detail: error.message,
-            dismissable: true
-          });
+          showWarningNotification(`Failed to stat file ${filePath}`, error);
           return empty();
         })
       );

--- a/lib/flow-types/Note.js
+++ b/lib/flow-types/Note.js
@@ -13,7 +13,7 @@ export type Note = {
   birthtime?: number,
   content?: string,
   fileIcons?: string | void,
-  lastupdate?: number,
+  mtime?: number,
   nvtags?: string[] | void,
   nvtagstr?: string | void,
   ready?: boolean

--- a/lib/getValidDirFromPath-spec.js
+++ b/lib/getValidDirFromPath-spec.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import getValidDirFromPath from "./getValidDirFromPath";
+import fs from "fs-plus";
 
 const assertCommons = dir => {
   expect(dir).toEqual(jasmine.any(String));
@@ -10,6 +11,11 @@ const assertCommons = dir => {
 describe("getValidDirFromPath", function() {
   let dir;
 
+  beforeEach(function() {
+    spyOn(fs, "existsSync").andReturn(true);
+    spyOn(fs, "mkdirSync");
+  });
+
   it("should return default path if no path is set", function() {
     dir = getValidDirFromPath("");
     assertCommons(dir);
@@ -18,6 +24,8 @@ describe("getValidDirFromPath", function() {
     dir = getValidDirFromPath("  ");
     assertCommons(dir);
     expect(dir).toMatch(/.+notes$/);
+    expect(fs.existsSync).toHaveBeenCalledWith(jasmine.any(String));
+    expect(fs.mkdirSync).not.toHaveBeenCalled();
   });
 
   it("should expand any relative path dir to absoute dir in user's home dir", function() {
@@ -38,5 +46,13 @@ describe("getValidDirFromPath", function() {
     assertCommons(dir);
     expect(dir).toMatch(/.+home-notes$/);
     expect(dir).not.toEqual("~/home-notes");
+  });
+
+  it("should create directory if it does not exist", function() {
+    const dir = "/tmp/notes";
+    fs.existsSync.andReturn(false);
+    getValidDirFromPath(dir);
+    expect(fs.existsSync).toHaveBeenCalledWith(jasmine.any(String));
+    expect(fs.mkdirSync).toHaveBeenCalledWith(dir, 0o755);
   });
 });

--- a/lib/getValidDirFromPath.js
+++ b/lib/getValidDirFromPath.js
@@ -1,24 +1,26 @@
 /* @flow */
 
-import Path from "path";
+import path from "path";
 import fs from "fs-plus";
 
-export default function validatePath(path: string) {
-  path = path.trim();
+export default function validatePath(notesPath: string) {
+  notesPath = notesPath.trim();
 
-  if (path === "") {
-    return Path.join(atom.configDirPath, "notes");
+  if (notesPath === "") {
+    notesPath = path.join(atom.configDirPath, "notes");
   }
 
-  path = fs.absolute(path); // e.g. ~/something => /Users/alice/something
+  notesPath = fs.absolute(notesPath); // e.g. ~/something => /Users/alice/something
 
-  if (!fs.isAbsolute(path)) {
-    path = Path.join(fs.getHomeDirectory(), path);
+  if (!fs.isAbsolute(notesPath)) {
+    notesPath = path.join(fs.getHomeDirectory(), notesPath);
   }
 
-  path = Path.resolve(path); // removes any trailing slash
+  notesPath = path.resolve(notesPath); // removes any trailing slash
 
-  // TODO workflow for "faulty" path, e.g. can't read dir etc. should degrade gracefully or hint user how to resolve
+  if (!fs.existsSync(notesPath)) {
+    fs.mkdirSync(notesPath, 0o755);
+  }
 
-  return path;
+  return notesPath;
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,6 +5,7 @@ import Session from "./Session";
 import { defaultConfig } from "./config";
 import FileIconsReader from "./file-readers/FileIconsReader";
 import getValidDirFromPath from "./getValidDirFromPath";
+import { showWarningNotification } from "./showWarningNotification";
 
 export const config = defaultConfig;
 
@@ -33,7 +34,12 @@ export function deactivate() {
 }
 
 function startSession() {
-  const dir = getValidDirFromPath(atom.config.get("textual-velocity.path"));
+  let dir = "";
+  try {
+    dir = getValidDirFromPath(atom.config.get("textual-velocity.path"));
+  } catch (error) {
+    return showWarningNotification("Could not validate notes directory", error);
+  }
 
   disposeStartSessionCmd();
   session = new Session();

--- a/lib/note-fields/StatsDateNoteField-spec.js
+++ b/lib/note-fields/StatsDateNoteField-spec.js
@@ -30,13 +30,16 @@ describe("fields/StatsDateNoteField", function() {
         ext: "",
         stats: statsMock({ birthtime: new Date() })
       };
+      actual = undefined;
       if (field.value) {
         actual = field.value(note);
       }
       expect(actual).toEqual(jasmine.any(Number));
 
+      // assert last update
       // $FlowFixMe incomplete stats, to verify undefined actual below
       note.stats = {};
+      actual = undefined;
       if (field.value) {
         actual = field.value(note);
       }
@@ -44,13 +47,14 @@ describe("fields/StatsDateNoteField", function() {
 
       field = new StatsDateNoteField({
         notePropName: "name",
-        statsPropName: "lastupdate"
+        statsPropName: "mtime"
       });
       note.stats = statsMock({ birthtime: new Date() });
+      actual = undefined;
       if (field.value) {
         actual = field.value(note);
       }
-      expect(actual).toBeUndefined();
+      expect(actual).toEqual(jasmine.any(Number));
     });
   });
 });

--- a/lib/note-fields/StatsDateNoteField.js
+++ b/lib/note-fields/StatsDateNoteField.js
@@ -3,11 +3,16 @@
 import type { INoteField } from "../flow-types/INoteField";
 import type { Note, NotePropName } from "../flow-types/Note";
 
+type StatsPropName = "birthtime" | "mtime";
+
 export default class StatsDateNoteField implements INoteField {
   notePropName: NotePropName;
-  _statsPropName: string;
+  _statsPropName: StatsPropName;
 
-  constructor(params: { notePropName: NotePropName, statsPropName: string }) {
+  constructor(params: {
+    notePropName: NotePropName,
+    statsPropName: StatsPropName
+  }) {
     this.notePropName = params.notePropName;
     this._statsPropName = params.statsPropName;
   }


### PR DESCRIPTION
If enabled Atom v1.28 appear to crash consistently due to some reads.
Disable it by default, but can be enabled by package setting if someone really wants it.

+some other fixes