### PR TITLE
Enable sort by default search score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [keepachan
 
 
 ## [unreleased]
+#### Changed
+- Clicking column cycles desc -> asc -> unselect column for sorting. When no column is selected the results are sorted by the default search match score in descending order, i.e. closest match appears first.
 
 
 ## [0.21.0] - 2019-10-03

--- a/flow-typed/npm/sifter_vx.x.x.js
+++ b/flow-typed/npm/sifter_vx.x.x.js
@@ -13,18 +13,16 @@
  * https://github.com/flowtype/flow-typed
  */
 
-type sifter$SortDirectionSearchOption = 'asc' | 'desc'
-
-type sifter$SortSearchOption = {
-  direction?: sifter$SortDirectionSearchOption;
+type sifter$SortSearchOptions = {
+  direction?: 'asc' | 'desc';
   field: string;
 }
 
 type sifter$SearchOptions = {
   fields: string[];
   limit?: number | void;
-  sort?: sifter$SortSearchOption[];
-  sort_empty?: sifter$SortSearchOption[];
+  sort?: sifter$SortSearchOptions[];
+  sort_empty?: sifter$SortSearchOptions[];
   filter?: boolean;
   conjunction?: 'and' | 'or';
   nesting?: boolean;
@@ -47,10 +45,9 @@ type sifter$SearchResult<T> = {
 
 declare module 'sifter' {
 
-  declare export type SortSearchOption = sifter$SortSearchOption;
+  declare export type SortSearchOptions = sifter$SortSearchOptions;
   declare export type SearchOptions = sifter$SearchOptions;
   declare export type SearchResult<T> = sifter$SearchResult<T>;
-  declare export type SortDirection = sifter$SortDirectionSearchOption;
 
   declare class Sifter<T> {
     items: T;

--- a/flow-types/SortDirection.js
+++ b/flow-types/SortDirection.js
@@ -1,0 +1,2 @@
+/* @flow */
+export type SortDirection = "asc" | "desc";

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1,7 +1,7 @@
 /* @flow */
-import type { SortDirection } from "sifter";
 import type { FileReadResult, RawFile } from "../flow-types/File";
 import type { NotePropName } from "../flow-types/Note";
+import type { SortDirection } from "../flow-types/SortDirection";
 
 export type Action =
   | ChangedActivePaneItem
@@ -10,6 +10,7 @@ export type Action =
   | ChangedRowHeight
   | ChangedSortDirection
   | ChangedSortField
+  | ChangeSort
   | DisposeStore
   | EditCell
   | EditCellAbort
@@ -105,6 +106,18 @@ type ChangedSortField = {
 export function changeSortField(sortField: string): ChangedSortField {
   return {
     type: CHANGED_SORT_FIELD,
+    sortField
+  };
+}
+
+export const CHANGE_SORT = "CHANGE_SORT";
+export type ChangeSort = {
+  type: "CHANGE_SORT",
+  sortField: string
+};
+export function changeSort(sortField: string): ChangeSort {
+  return {
+    type: CHANGE_SORT,
     sortField
   };
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -30,12 +30,17 @@ export const defaultConfig = (cfg => {
     description: `${restartExplanation}<br/>Files ignored by the the notes path's VCS system will be ignored. For example, projects using Git have these paths defined in the .gitignore file.`
   },
   sortField: {
-    default: "name",
+    default: "$score",
     type: "string",
-    enum: columns.map(c => ({
-      value: c.sortField,
-      description: c.title
-    }))
+    enum: columns
+      .map(c => ({
+        value: c.sortField,
+        description: c.title
+      }))
+      .concat({
+        value: "$score",
+        description: "Search match score"
+      })
   },
   sortDirection: {
     type: "string",

--- a/lib/epics/configChangesEpic.js
+++ b/lib/epics/configChangesEpic.js
@@ -10,10 +10,15 @@ import {
 import observeConfig from "../atom-rxjs/observeConfig";
 import * as A from "../actions";
 import takeUntilDispose from "../takeUntilDispose";
+import setSortConfigs from "../side-effects/setSortConfigs";
 
 import type { Action } from "../actions";
+import type { State } from "../../flow-types/State";
 
-export default function configChangesEpic(action$: rxjs$Observable<Action>) {
+export default function configChangesEpic(
+  action$: rxjs$Observable<Action>,
+  state$: reduxRxjs$StateObservable<State>
+) {
   return merge(
     observeConfig("textual-velocity.listHeight").pipe(
       map(A.changeListHeight),
@@ -45,15 +50,14 @@ export default function configChangesEpic(action$: rxjs$Observable<Action>) {
               atom.config.set("textual-velocity.rowHeight", action.rowHeight);
               break;
 
-            case A.CHANGED_SORT_DIRECTION:
-              atom.config.set(
-                "textual-velocity.sortDirection",
-                action.sortDirection
-              );
+            case A.CHANGE_SORT: {
+              const state = state$.value;
+              const lastSort =
+                state.sifterResult.options.sort &&
+                state.sifterResult.options.sort[0];
+              setSortConfigs(action.sortField, lastSort);
               break;
-
-            case A.CHANGED_SORT_FIELD:
-              atom.config.set("textual-velocity.sortField", action.sortField);
+            }
           }
 
           return false; // to avoid creating an infinite loop (see https://redux-observable.js.org/docs/basics/Epics.html)

--- a/lib/react/containers/TableColumn.js
+++ b/lib/react/containers/TableColumn.js
@@ -12,24 +12,21 @@ const mapStateToProps = (state: State) => {
   const sort = state.sifterResult.options.sort;
   if (sort && sort[0]) {
     return {
-      sortDirection: sort[0].direction || "desc",
+      sortDirection: sort[0].direction,
       sortField: sort[0].field
     };
-  } else {
-    return {
-      sortDirection: "desc",
-      sortField: "summary"
-    };
   }
+
+  return {
+    sortDirection: "desc",
+    sortField: "$score"
+  };
 };
 
 const mapDispatchToProps = (dispatch: Dispatch<Action>) => {
   return {
-    onChangeSortDirection: direction => {
-      dispatch(A.changeSortDirection(direction));
-    },
-    onSortByField: sortField => {
-      dispatch(A.changeSortField(sortField));
+    onClickColumn: (sortField: string) => {
+      dispatch(A.changeSort(sortField));
     }
   };
 };

--- a/lib/react/presentationals/TableColumn.js
+++ b/lib/react/presentationals/TableColumn.js
@@ -3,58 +3,41 @@
 import * as React from "react";
 import classNames from "classnames";
 
-import type { SortDirection } from "sifter";
+import type { SortDirection } from "../../../flow-types/SortDirection";
 import type { ColumnHeader } from "../../../flow-types/ColumnHeader";
 
 type Props = {
   column: ColumnHeader,
   sortDirection: SortDirection,
   sortField: string,
-  onSortByField: Function,
-  onChangeSortDirection: Function
+  onClickColumn: (sortField: string) => void
 };
 
 export default class TableColumn extends React.Component<Props> {
   render() {
-    const c = this.props.column;
-    const isSelected = this._isSelected();
+    const { column, sortDirection } = this.props;
+    const isSelected = column.sortField === this.props.sortField;
     return (
       <th
-        style={{ width: `${c.width}%` }}
+        style={{ width: `${column.width}%` }}
         className={classNames({ "is-selected": isSelected })}
         onClick={this._onClick.bind(this)}
       >
-        {c.title}
+        {column.title}
         &nbsp;
-        {this._sortIndicator(isSelected)}
+        <span
+          className={classNames({
+            icon: true,
+            "is-hidden": !isSelected,
+            "icon-triangle-up": sortDirection === "asc",
+            "icon-triangle-down": sortDirection === "desc"
+          })}
+        />
       </th>
     );
   }
 
-  _sortIndicator(isSelected: boolean) {
-    if (isSelected) {
-      return (
-        <span
-          className={classNames({
-            icon: true,
-            "icon-triangle-up": this.props.sortDirection === "asc",
-            "icon-triangle-down": this.props.sortDirection === "desc"
-          })}
-        />
-      );
-    }
-  }
-
   _onClick() {
-    if (this._isSelected()) {
-      const direction = this.props.sortDirection === "asc" ? "desc" : "asc";
-      this.props.onChangeSortDirection(direction);
-    } else {
-      this.props.onSortByField(this.props.column.sortField);
-    }
-  }
-
-  _isSelected() {
-    return this.props.sortField === this.props.column.sortField;
+    this.props.onClickColumn(this.props.column.sortField);
   }
 }

--- a/lib/reducers/selectedNoteReducer.js
+++ b/lib/reducers/selectedNoteReducer.js
@@ -30,6 +30,7 @@ export default function selectedNoteReducer(
     case A.SELECT_NOTE:
       return getSelectedNote(nextSifterResult, action.filename);
 
+    case A.CHANGE_SORT:
     case A.CHANGED_SORT_FIELD:
     case A.CHANGED_SORT_DIRECTION:
       return getSelectedNote(nextSifterResult, state && state.filename);

--- a/lib/reducers/sifterResultReducer.js
+++ b/lib/reducers/sifterResultReducer.js
@@ -10,12 +10,12 @@ import type { SifterResult } from "../../flow-types/SifterResult";
 
 const sifter: Sifter<Notes> = new Sifter();
 
-const secondarySort = { field: "$score", direction: "desc" };
+const DEFAULT_SORT = { field: "$score", direction: "desc" };
 const defaults = {
   items: [],
   options: {
     fields: [],
-    sort: [secondarySort]
+    sort: [DEFAULT_SORT]
   },
   query: "",
   tokens: [],
@@ -41,6 +41,7 @@ export default function sifterResultReducer(
     case A.FILE_DELETED:
     case A.FILE_READ:
     case A.FILE_RENAMED:
+      // These actions do not modify the query, but should trigger a new search for the results to match changed state
       break;
 
     case A.CHANGED_SORT_FIELD:
@@ -61,20 +62,19 @@ export default function sifterResultReducer(
   }
 
   sifter.items = nextNotes; // use notes as items to be search
-  let sort = state.options.sort && state.options.sort[0];
-  if (!sort) {
-    sort = secondarySort;
-  }
+  let lastSort = state.options.sort && state.options.sort[0];
 
   return sifter.search(query, {
     fields: noteFields.map(noteField => noteField.notePropName),
-    sort: [
-      {
-        field: field || sort.field,
-        direction: direction || sort.direction
-      },
-      secondarySort
-    ],
+    sort: lastSort
+      ? [
+          {
+            field: field || lastSort.field,
+            direction: direction || lastSort.direction
+          },
+          DEFAULT_SORT
+        ]
+      : [DEFAULT_SORT],
     conjunction: "and"
   });
 }

--- a/lib/side-effects/setSortConfigs.js
+++ b/lib/side-effects/setSortConfigs.js
@@ -1,0 +1,43 @@
+/* @flow */
+
+import type { SortDirection } from "../../flow-types/SortDirection";
+import type { SortSearchOptions } from "sifter";
+
+const DEFAULT_SORT_DIRECTION = "desc";
+
+const transactSet = (sortField: string, sortDirection: SortDirection) => {
+  atom.config.transact(() => {
+    atom.config.set("textual-velocity.sortField", sortField);
+    atom.config.set("textual-velocity.sortDirection", sortDirection);
+  });
+};
+
+// Set sort configs will handle the expected state transition when a column is clicked
+export default function setSortConfigs(
+  sortField: string,
+  lastSort?: SortSearchOptions
+) {
+  if (!lastSort) {
+    // Either prev sort was using default $score sort, or there is no result to use
+    // In either case, update with the new sort field
+    transactSet(sortField, DEFAULT_SORT_DIRECTION);
+    return;
+  }
+
+  if (sortField === lastSort.field) {
+    switch (lastSort.direction) {
+      case "desc":
+        transactSet(sortField, "asc");
+        return;
+      case "asc":
+        transactSet("$score", "desc");
+        return;
+      default:
+        transactSet(sortField, DEFAULT_SORT_DIRECTION);
+        return;
+    }
+  } else {
+    // Sort field changed, update with last sort direction
+    transactSet(sortField, lastSort.direction || DEFAULT_SORT_DIRECTION);
+  }
+}

--- a/spec/epics/configChangesEpic-spec.js
+++ b/spec/epics/configChangesEpic-spec.js
@@ -27,7 +27,7 @@ describe("epics/configChangesEpic", () => {
     expect(dispatchedActions[0]).toEqual(A.changeListHeight(150));
     expect(dispatchedActions[1]).toEqual(A.changeRowHeight(20));
     expect(dispatchedActions[2]).toEqual(A.changeSortDirection("desc"));
-    expect(dispatchedActions[3]).toEqual(A.changeSortField("name"));
+    expect(dispatchedActions[3]).toEqual(A.changeSortField("$score"));
   });
 
   describe("when resized list action", function() {
@@ -40,7 +40,7 @@ describe("epics/configChangesEpic", () => {
       jasmine.Clock.tick(1000);
     });
 
-    it("should have updated list Height", function() {
+    it("should have updated listHeight", function() {
       expect(atom.config.get("textual-velocity.listHeight")).toEqual(123);
     });
 
@@ -61,56 +61,13 @@ describe("epics/configChangesEpic", () => {
       jasmine.Clock.tick(1000);
     });
 
-    it("should have updated list Height", function() {
+    it("should have updated rowHeight", function() {
       expect(atom.config.get("textual-velocity.rowHeight")).toEqual(26);
     });
 
     it("should have yielded a last action", function() {
       const lastActions = store.getActions().slice(-1);
       expect(lastActions[0]).toEqual(A.changeRowHeight(26));
-    });
-  });
-
-  describe("when changed sort direction", function() {
-    let sortDirectionSpy;
-
-    beforeEach(function() {
-      sortDirectionSpy = jasmine.createSpy("sortDirection");
-      atom.config.onDidChange(
-        "textual-velocity.sortDirection",
-        sortDirectionSpy
-      );
-      store.dispatch(A.changeSortDirection("asc"));
-      jasmine.Clock.tick(1000);
-    });
-
-    it("should have updated list Height", function() {
-      expect(atom.config.get("textual-velocity.sortDirection")).toEqual("asc");
-    });
-
-    it("should have yielded a last action", function() {
-      const lastActions = store.getActions().slice(-1);
-      expect(lastActions[0]).toEqual(A.changeSortDirection("asc"));
-    });
-  });
-
-  describe("when changed sort field", function() {
-    let sortFieldSpy;
-
-    beforeEach(function() {
-      sortFieldSpy = jasmine.createSpy("sortField");
-      atom.config.onDidChange("textual-velocity.sortField", sortFieldSpy);
-      store.dispatch(A.changeSortField("ext"));
-      jasmine.Clock.tick(1000);
-    });
-
-    it("should have updated list Height", function() {
-      expect(atom.config.get("textual-velocity.sortField")).toEqual("ext");
-    });
-
-    it("should have yielded a last action", function() {
-      const lastActions = store.getActions().slice(-1);
-      expect(lastActions[0]).toEqual(A.changeSortField("ext"));
     });
   });
 });

--- a/styles/textual-velocity.less
+++ b/styles/textual-velocity.less
@@ -116,6 +116,11 @@
     &.is-selected {
       color: @text-color;
     }
+    & .icon.is-hidden:before {
+      // hack to make the height remain the same even if the sort icon is not visible
+      width: 0;
+      overflow: hidden;
+    }
   }
   td {
     cursor: pointer;


### PR DESCRIPTION
Click multiple times on selected column makes it cycle through stats of desc -> asc -> unselected, for which the last state means the results are ordered by search score in descending order.